### PR TITLE
Define Base.print for WExpr

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,16 @@ julia> W"Sin"
 W"Sin"
 
 julia> sin1 = W"Sin"(1.0)
-W"Sin(1.0)"
+W"Sin"(1.0)
 
 julia> sinx = W"Sin"(W"x")
 W"Sin"(W"x")
+
+julia> int = W"Integrate"(sinx, (W"x", 0, 1))
+W"Integrate"(W"Sin"(W"x"), (W"x", 0, 1))
+
+julia> println(int)
+Integrate[Sin[x], {x, 0, 1}]
 ```
 
 To parse an expression in the Wolfram Language, you can use the `W` cmd macro (note the backticks):
@@ -44,7 +50,7 @@ julia> weval(sin1)
 julia> weval(sinx)
 W"Sin"(W"x")
 
-julia> weval(W"Integrate"(sinx, (W"x", 0, 1)))
+julia> weval(int)
 W"Plus"(1, W"Times"(-1, W"Cos"(1)))
 ```
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -34,6 +34,27 @@ struct WExpr
     args
 end
 
+function Base.print(io::IO, w::WExpr)
+    print(io, w.head)
+    print(io, "[")
+    isfirst = true
+    for arg in w.args
+        if !isfirst
+            print(io, ", ")
+        else
+            isfirst = false
+        end
+        if typeof(arg) <: Union{AbstractVector, Tuple}
+            print(io, "{")
+            join(io, arg, ", ")
+            print(io, "}")
+        else
+            print(io, arg)
+        end
+    end
+    print(io, ']')
+end
+
 function Base.show(io::IO, w::WExpr)
     show(io, w.head)
     print(io, '(')


### PR DESCRIPTION
This will make `WExpr` be printed more pleasantly.