### PR TITLE
mathlink macos wolfram engine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 Manifest.toml
 deps/deps.jl
-
+deps/*.log

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ The package requires an installation of either [Mathematica](http://www.wolfram.
 - `JULIA_MATHLINK`: the path of the MathLink dynamic library named
   - `libML64i4.so`/ `libML32i4.so` on Linux
   - `libML64.dll`/ `libML32.dll` on Windows
-  - `mathlink` on macOS
-
+  - `mathlink` on macOS (if the free Wolfram Engine is used you need to set `ENV["JULIA_MATHLINK"] = "/Applications/Wolfram Engine.app/Contents/Resources/Wolfram Player.app/Contents/SystemFiles/Links/MathLink/DeveloperKit/MacOSX-x86-64/CompilerAdditions/mathlink.framework/mathlink"`)
+  
 ## Usage
 
 The main interface consists of the `W""` string macro for specifying symbols. These are call-overloaded for building more complicated expressions 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ The package requires an installation of either [Mathematica](http://www.wolfram.
 - `JULIA_MATHLINK`: the path of the MathLink dynamic library named
   - `libML64i4.so`/ `libML32i4.so` on Linux
   - `libML64.dll`/ `libML32.dll` on Windows
-  - `mathlink` on macOS (if the free Wolfram Engine is used you need to set `ENV["JULIA_MATHLINK"] = "/Applications/Wolfram Engine.app/Contents/Resources/Wolfram Player.app/Contents/SystemFiles/Links/MathLink/DeveloperKit/MacOSX-x86-64/CompilerAdditions/mathlink.framework/mathlink"`)
   
 ## Usage
 

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -17,7 +17,7 @@ function find_lib_ker()
         end
 
         # Wolfram Engine
-        for path in readlines(`mdfind "kMDItemCFBundleIdentifier == 'com.wolfram.engine'"`)
+        for path in readlines(`mdfind "kMDItemCFBundleIdentifier == 'com.wolfram.*'"`)
             # kernels are located in sub-application
             subpath = joinpath(path, "Contents/Resources/Wolfram Player.app")
             lib = joinpath(subpath,"Contents/Frameworks/mathlink.framework/mathlink")


### PR DESCRIPTION
This took me a while to find when using the free Wolfram Engine. With Mathematica this is automatically linked, so no problem.