### PR TITLE
Overloading of arithithmetic operators 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 Manifest.toml
 deps/deps.jl
 deps/*.log
+*~

--- a/README.md
+++ b/README.md
@@ -58,6 +58,80 @@ julia> weval(sinx; x=2.0)
 0.9092974268256817
 ```
 
+## The algebraic operators
+
+MathLink also overloads the `+`, `-`, `*`, `/`  operations
+
+```julia
+julia> using MathLink
+
+julia> W"a"+W"b"
+W"Plus"(W"a",W"b")
+
+julia> W"a"+W"a"
+W"Plus"(W"a",W"a")
+
+julia> W"a"-W"a"
+W"Plus"(W"a",W"Minus"(W"a"))
+```
+
+One can toggle automatic use of `weval`  on-and-off using `set_GreedyEval(x::Bool)`
+
+```julia
+julia>set_GreedyEval(true)
+julia> W"a"+W"b"
+W"Plus"(W"a",W"b")
+
+julia> W"a"+W"a"
+W"Times"(2,W"a")
+
+julia> W"a"-W"a"
+0
+```
+
+
+## Fractions and Complex numbers
+ 
+The package also contains extentions to handle fractions
+
+```julia
+julia> weval(1//2)
+W"Rational"(1, 2)
+
+julia> (4//5)*W"a"
+W"Times"(W"Rational"(4, 5), W"a")
+
+julia> W"a"/(4//5)
+W"Times"(W"Rational"(5, 4), W"a")
+```
+
+and complex numbers
+
+```julia
+julia> im*W"a"
+W"Times"(W"Complex"(0, 1), W"a")
+
+julia> im*(im*W"c")
+W"Times"(-1, W"c")
+```
+
+
+## Matrix Multiplication
+Since the arithematic operators are overloaded, operations such as matrix multiplication are also possible by default
+
+```julia
+julia> P12 = [ 0 1 ; 1 0 ]
+2×2 Matrix{Int64}:
+ 0  1
+ 1  0
+
+julia> set_GreedyEval(true)
+true
+
+julia> P12 * [W"a" W"b" ; W`a+b` 2] == [ W"b" 2-W"b" ; W"a" W"b"]
+true
+```
+
 ## Notes
 
 - Mathematica, Wolfram, MathLink are all trademarks of Wolfram Research.

--- a/src/MathLink.jl
+++ b/src/MathLink.jl
@@ -13,5 +13,6 @@ include("wstp.jl")
 include("extras.jl")
 include("eval.jl")
 include("display.jl")
+include("operators.jl")
 
 end

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -1,0 +1,104 @@
+
+import Base.+
+import Base.*
+import Base.-
+import Base./
+import Base.//
+import Base.^
+import Base.zero
+#### + ####
+
+
+####If the flag for greedy evaluation does not exist
+## create it and set it to false.
+if !@isdefined(MLGreedyEval)
+    MLGreedyEval=false
+end
+
+function MLeval(x::WTypes)
+    #println("MLGreedyEval=$MLGreedyEval")
+    if MLGreedyEval
+        return weval(x)
+    else
+        return x
+    end
+end
+
+export set_GreedyEval
+
+function set_GreedyEval(x::Bool)
+    global MLGreedyEval
+    MLGreedyEval=x
+end
+
+
+###A special case of weval on rationals that was not handled
+zero(x::WTypes)=0
+
++(a::WTypes)=MLeval(a)
++(a::WTypes,b::WTypes)=MLeval(W"Plus"(a,b))
++(a::WTypes,b::Number)=MLeval(W"Plus"(a,b))
++(a::Number,b::WTypes)=MLeval(W"Plus"(a,b))
++(a::WTypes,b::Complex)=a+WComplex(b)
++(a::Complex,b::WTypes)=WComplex(a)+b
+#### - ####
+-(a::WTypes)=MLeval(W"Minus"(a))
+-(a::WTypes,b::WTypes)=MLeval(W"Plus"(a,W"Minus"(b)))
+-(a::WTypes,b::Number)=MLeval(W"Plus"(a,W"Minus"(b)))
+-(a::Number,b::WTypes)=MLeval(W"Plus"(a,W"Minus"(b)))
+-(a::WTypes,b::Complex)=a-WComplex(b)
+-(a::Complex,b::WTypes)=WComplex(a)-b
+
+
+#### * ####
+*(a::WTypes,b::WTypes)=MLeval(W"Times"(a,b))
+*(a::WTypes,b::Number)=MLeval(W"Times"(a,b))
+*(a::Number,b::WTypes)=MLeval(W"Times"(a,b))
+*(a::WTypes,b::Rational)=a*WRational(b)
+*(a::Rational,b::WTypes)=WRational(a)*b
+*(a::WTypes,b::Complex)=a*WComplex(b)
+*(a::Complex,b::WTypes)=WComplex(a)*b
+
+
+#### // ####
+//(a::WTypes,b::WTypes)=MLeval(W"Times"(a, W"Power"(b, -1)))
+//(a::WTypes,b::Number)=MLeval(W"Times"(a, W"Power"(b, -1)))
+//(a::Number,b::WTypes)=MLeval(W"Times"(a, W"Power"(b, -1)))
+//(a::WTypes,b::Rational)=a//WRational(b)
+//(a::Rational,b::WTypes,)=WRational(a)//b
+//(a::WTypes,b::Complex)=a//WComplex(b)
+//(a::Complex,b::WTypes,)=WComplex(a)//b
+                               
+
+#### / ####
+/(a::WTypes,b::WTypes)=a//b
+/(a::WTypes,b::Number)=a//b
+/(a::Number,b::WTypes)=a//b
+
+
+#### ^ ####
+^(a::WTypes,b::WTypes)=MLeval(W"Power"(a,b))
+^(a::WTypes,b::Number)=MLeval(W"Power"(a,b))
+^(a::Number,b::WTypes)=MLeval(W"Power"(a,b))
+
+WRational(x::Rational) = W"Times"(x.num, W"Power"(x.den, -1))
+WComplex(x::Complex) = W"Complex"(x.re,x.im)
+function WComplex(x::Complex{Bool})
+    if x.re
+        re = 1
+    else
+        re = 0
+    end
+    if x.im
+        im = 1
+    else
+        im = 0
+    end
+    return W"Complex"(re,im)
+end
+
+###Added a function to put that handles rationals
+import MathLink.put
+MathLink.put(x::MathLink.Link,r::Rational)=MathLink.put(x,WRational(r))
+MathLink.put(x::MathLink.Link,z::Complex)=MathLink.put(x,WComplex(z))
+

--- a/src/types.jl
+++ b/src/types.jl
@@ -1,3 +1,6 @@
+abstract type WTypes end
+
+
 """
     WSymbol(name::Union{String, Symbol})
     W"..."
@@ -28,9 +31,9 @@ julia> weval(W"Simplify"(ex, Assumptions=assume))
 W"Times"(-1, W"x")
 ```
 """
-struct WSymbol
+struct WSymbol <: WTypes
     name::String
-end
+end 
 WSymbol(sym::Symbol) = WSymbol(String(sym))
 Base.print(io::IO, s::WSymbol) = print(io, s.name)
 Base.show(io::IO, s::WSymbol) = print(io, 'W', '"', s.name, '"')
@@ -45,7 +48,7 @@ end
 
 A Wolfram arbitrary-precision real number.
 """
-struct WReal
+struct WReal <: WTypes
     value::String
 end
 Base.show(io::IO, x::WReal) = print(io, x.value)
@@ -56,7 +59,7 @@ Base.:(==)(a::WReal, b::WReal) = a.value == b.value
 
 A Wolfram arbitrary-precision integer.
 """
-struct WInteger
+struct WInteger <: WTypes
     value::String
 end
 Base.show(io::IO, x::WInteger) = print(io, x.value)
@@ -78,7 +81,7 @@ julia> weval(W`Function[x,x+1]`(2))
 3
 ```
 """
-struct WExpr
+struct WExpr <: WTypes
     head
     args
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -74,3 +74,111 @@ end
 
     @test W`Cos[$(log(2))]` == W"Cos"(log(2))
 end
+
+
+
+@testset "README" begin
+    
+    ###The operations mentioned for MathLink the README
+    sin1 = W"Sin"(1.0)
+    @test sin1 == W"Sin"(1.0)
+    
+    sinx = W"Sin"(W"x")
+    @test sinx == W"Sin"(W"x")
+    @test W`Sin[1]` == W"Sin"(1)
+    
+    @test weval(sin1) == 0.8414709848078965
+
+    @test weval(sinx) == W"Sin"(W"x")
+    
+    @test weval(W"Integrate"(sinx, (W"x", 0, 1))) == W"Plus"(1, W"Times"(-1, W"Cos"(1)))
+end
+
+
+@testset "GreedyEval" begin
+    ###Testing turning on and turning of the greedy evaluation
+    ###The default is "false"
+    @test W"a"+W"b" == W"Plus"(W"a",W"b")
+    @test W"a"+W"a" == W"Plus"(W"a",W"a")
+    @test W"a"-W"a" == W"Plus"(W"a",W"Minus"(W"a"))
+    set_GreedyEval(true)
+    @test W"a"+W"b" == W"Plus"(W"a",W"b")
+    @test W"a"+W"a" == W"Times"(2,W"a")
+    @test W"a"-W"a" == 0
+    set_GreedyEval(false)
+    @test W"b"+W"b" == W"Plus"(W"b",W"b")
+    set_GreedyEval(true)
+end
+
+@testset "Rationals" begin
+    #### Test Rationals parts
+    @test (4//5)*W"a" == weval(W`4 a/5`)
+    @test W"a"*(4//5) == weval(W`4 a/5`)
+    @test (4//5)/W"a" == weval(W`4/(a 5)`)
+    @test W"a"/(4//5) == weval(W`5 a/4`)
+    @test weval(1//2) == weval(W`1/2`)
+    @test weval([1//2,W`a`]) == W"List"(weval(W`1/2`),W`a`)
+end
+
+@testset "Complex Numbers" begin
+    #### Test imaginary parts
+    @test im*W"a" == weval(W`I * a`)
+    @test (2*im)*W"a" == weval(W`2 I a`)
+    @test im/W"a" == weval(W`I / a`)
+    @test W"a"/(2* im) == weval(W`- I a/2`)
+    @test im*(im*W"c") == weval(W`-c`)
+  
+    
+    #####Testing that complex nubmers can be put in weval
+    @test weval(im+2) == weval(W`I+2`)
+    @test weval(im*2) == weval(W`I*2`)
+    @test weval(im) == weval(W`I`)
+    
+    @test (3*im)*(2*im)*W"a" == weval(W`-6 a`)
+    @test (3*im) + (2*im)*W"a" == weval(W`3 I + 2 I a`)
+    @test (3*im) - (2*im)*W"a" == weval(W`3 I - 2 I a`)
+end
+
+
+@testset "Unary operators" begin
+    @test +W"b" == W"b"
+    @test +W`a+b` == W`a+b`
+    @test -W"b" == W`-b`
+    @test -W`a-b` == W`-a+b`
+end
+
+
+
+
+@testset "Matrix Multiplication" begin
+
+    P12 = [ 0 1 ; 1 0 ]
+    @test P12 * [W"a" W"b" ; W`a+b` 2] == [ W`a+b` 2 ; W"a" W"b"]
+    @test [W"a" W"b" ; W`a+b` 2] * P12  == [ W"b" W"a" ; 2 W`a+b`]
+    
+    #### test larger matrix
+    @test P12 * [W"a" W"b" ; W`a+b` W`v+2`] == [ W`a+b` W`2+v` ; W"a" W"b"]
+    @test [W"a" W"b" ; W`a+b` W`v+2`] * P12  == [ W"b" W"a" ; W`2+v` W`a+b`]
+
+    #### test larger matrix
+    P13 = fill(0,(3,3))
+    P13[1,3]=1
+    P13[3,1]=1
+    P13[2,2]=1
+    Mat = fill(W`a+d`,3,3)
+    Mat[:,:] = [W`a+d` W`a+d` W`f*g`; W`a+b` W`v+2` W`f*g` ;  W`d+b`  W`a+b`  W`a+b`]
+    P13 * Mat * P13
+    #HM2 = P13*Mat*P13
+
+    ###A real live eample
+    P14 = fill(0,(4,4))
+    P14[1,4]=1
+    P14[4,1]=1
+    P14[2,2]=1
+    P14[3,3]=1
+    Mat = MathLink.WExpr[W"Plus"(W"J1245", W"J1346", W"J2356") W"Plus"(W"Times"(W"Complex"(0, 1), W"J1356"), W"Times"(W"Complex"(0, -1), W"J2346")) W"Plus"(W"Times"(W"Complex"(0, -1), W"J1256"), W"Times"(W"Complex"(0, 1), W"J2345")) W"Plus"(W"J1246", W"Times"(-1, W"J1345")); W"Plus"(W"Times"(W"Complex"(0, -1), W"J1356"), W"Times"(W"Complex"(0, 1), W"J2346")) W"Plus"(W"J1245", W"Times"(-1, W"J1346"), W"Times"(-1, W"J2356")) W"Plus"(W"J1246", W"J1345") W"Plus"(W"Times"(W"Complex"(0, -1), W"J1256"), W"Times"(W"Complex"(0, -1), W"J2345")); W"Plus"(W"Times"(W"Complex"(0, 1), W"J1256"), W"Times"(W"Complex"(0, -1), W"J2345")) W"Plus"(W"J1246", W"J1345") W"Plus"(W"Times"(-1, W"J1245"), W"J1346", W"Times"(-1, W"J2356")) W"Plus"(W"Times"(W"Complex"(0, -1), W"J1356"), W"Times"(W"Complex"(0, -1), W"J2346")); W"Plus"(W"J1246", W"Times"(-1, W"J1345")) W"Plus"(W"Times"(W"Complex"(0, 1), W"J1256"), W"Times"(W"Complex"(0, 1), W"J2345")) W"Plus"(W"Times"(W"Complex"(0, 1), W"J1356"), W"Times"(W"Complex"(0, 1), W"J2346")) W"Plus"(W"Times"(-1, W"J1245"), W"Times"(-1, W"J1346"), W"J2356")]
+    ####WE just want to see that the numbers can be computed
+    Mat * P14
+    P14 * Mat
+    P14 * Mat* P14
+end


### PR DESCRIPTION
First step in merging [MathLinkExtras](https://github.com/fremling/MathLinkExtras.jl) into MathLink.

Here
* support for +,-,*,/ as well as rationals and complex numbers is included, along with lots of tests.
* The readme has been updated to explain the functionality.
* An abstract super-type `WTypes` has been added to collect `WSymbol`, `WExpr`, `WNumber` and `WRationals` under one roof.
