### PR TITLE
Allow latex support in Jupyter notebooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,10 @@ julia> P12 * [W"a" W"b" ; W`a+b` 2] == [ W"b" 2-W"b" ; W"a" W"b"]
 true
 ```
 
+## LateX printing in JuPyter Notebooks
+Printing in Juypter notebooks is by defaults done in latex.
+This can be turned off with the command `MathLink.set_texOutput(false)`
+
 ## Notes
 
 - Mathematica, Wolfram, MathLink are all trademarks of Wolfram Research.

--- a/src/display.jl
+++ b/src/display.jl
@@ -1,4 +1,4 @@
-const graphics = (W"Graphics", W"Graphics3D", W"Legended")
+const graphics = (W"Graphics",W"GeoGraphics", W"Graphics3D", W"Legended")
 
 Base.Multimedia.showable(::MIME"image/svg+xml", w::MathLink.WExpr) = in(w.head, graphics)
 Base.show(io::IO, ::MIME"image/svg+xml", w::MathLink.WExpr) = print(io, weval(W"ExportString"(w, "SVG")))
@@ -8,3 +8,73 @@ function Base.show(io::IO, ::MIME"image/png", w::MathLink.WExpr)
     x = weval(W"ExportByteArray"(w, "PNG"))
     write(io, x.args[1].args)
 end
+
+
+export HasGraphicsHead, HasRecursiveGraphicsHead, W2Tex
+
+
+#### Code to produce LaTex strings
+W2Tex(x::WTypes) = weval(W`ToString@TeXForm[#]&`(x))
+
+#### Allow latex string to be shown when supported. Relevant for the jupyter notebook.
+
+HasRecursiveGraphicsHead(w::MathLink.WSymbol) = false
+function HasRecursiveGraphicsHead(w::MathLink.WExpr)
+    if HasGraphicsHead(w)
+        return true
+    end
+    for arg in w.args
+        if typeof(arg) == MathLink.WExpr
+            ##Only check for MathLink Expressions
+            if HasRecursiveGraphicsHead(arg)
+                return true
+            end
+        end
+    end
+    return false
+end
+
+function HeadsEndsWith(HeadString,Target)
+    ###Check if name ends with $Target
+    if length(HeadString) >= length(Target)  
+        return  HeadString[end-(length(Target)-1):end] == Target
+    end
+    return false
+end
+
+
+const graphics_heads = (W"Graphics", W"Graphics3D", W"Legended")
+
+###Check if an expression has a grapics head
+HasGraphicsHead(w::MathLink.WSymbol) = false
+function HasGraphicsHead(w::MathLink.WExpr)
+    HeadString = w.head.name
+    ###Check for graphics related names not based on ending on Plot* or Chart*
+    if in(w.head, graphics)
+        return  true
+    end
+
+    HeadsEndsWith(HeadString,"Plot") && return true
+    HeadsEndsWith(HeadString,"Chart") && return true
+    HeadsEndsWith(HeadString,"Plot3D") && return true
+    HeadsEndsWith(HeadString,"Chart3D") && return true
+    return false
+end
+
+import Base.show
+Base.show(io,::MIME"text/latex",x::MathLink.WSymbol) = print(io,"\$"*W2Tex(x)*"\$")
+
+import Base.Multimedia.showable
+function Base.Multimedia.showable(::MIME"text/latex", w::MathLink.WExpr)
+    if HasRecursiveGraphicsHead(w)
+        return false
+    else
+        return true
+    end
+end
+function Base.show(io,::MIME"text/latex",x::MathLink.WExpr)
+    print(io,"\$"*W2Tex(x)*"\$")
+end
+
+
+

--- a/src/display.jl
+++ b/src/display.jl
@@ -10,6 +10,18 @@ function Base.show(io::IO, ::MIME"image/png", w::MathLink.WExpr)
 end
 
 
+####If the flag for tex-output evaluation does not exist
+## create it and set it to true.
+if !@isdefined(MLtexOutput)
+    MLtexOutput=true
+end
+
+export set_texOutput
+function set_texOutput(x::Bool)
+    global MLtexOutput
+    MLtexOutput=x
+end
+
 export HasGraphicsHead, HasRecursiveGraphicsHead, W2Tex
 
 
@@ -62,10 +74,14 @@ function HasGraphicsHead(w::MathLink.WExpr)
 end
 
 import Base.show
+Base.Multimedia.showable(::MIME"text/latex", w::MathLink.WSymbol) = MLtexOutput
 Base.show(io,::MIME"text/latex",x::MathLink.WSymbol) = print(io,"\$"*W2Tex(x)*"\$")
 
 import Base.Multimedia.showable
 function Base.Multimedia.showable(::MIME"text/latex", w::MathLink.WExpr)
+    if !MLtexOutput
+        return false
+    end
     if HasRecursiveGraphicsHead(w)
         return false
     else

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -182,3 +182,43 @@ end
     P14 * Mat
     P14 * Mat* P14
 end
+
+
+
+
+@testset  "Find Graphiscs" begin
+    @test !HasGraphicsHead(W"a")
+    @test HasGraphicsHead(W`Plot[x,{x,0,1}]`)
+    @test HasGraphicsHead(W`ListPlot[x,{x,0,1}]`)
+    @test HasGraphicsHead(W`ListLinePlot3D[x,{x,0,1}]`)
+    @test HasGraphicsHead(W`Plot3D[x,{x,0,1}]`)
+    @test !HasGraphicsHead(W"a"+W"b")
+    @test HasGraphicsHead(weval(W`Plot[x,{x,0,1}]`))
+    @test !HasGraphicsHead(W`{Plot[x,{x,0,1}],Plot[x^2,{x,0,1}]}`)
+    @test !HasGraphicsHead(weval(W`{Plot[x,{x,0,1}],Plot[x^2,{x,0,1}]}`))
+
+    @test !HasRecursiveGraphicsHead(W`{2,a+v,{4+d}}`)
+    @test HasRecursiveGraphicsHead(W`Plot[x,{x,0,1}]`)
+    @test HasRecursiveGraphicsHead(W`{2,Plot[x^2,{x,0,1}]}`)
+    @test HasRecursiveGraphicsHead(W`{a+b,Plot[x^2,{x,0,1}]}`)
+    @test HasRecursiveGraphicsHead(W`{Plot[x,{x,0,1}],Plot[x^2,{x,0,1}]}`)
+    @test HasRecursiveGraphicsHead(W`{1,{Plot[x,{x,0,1}],Plot[x^2,{x,0,1}]}}`)
+    @test HasRecursiveGraphicsHead(weval(W`{Plot[x,{x,0,1}],Plot[x^2,{x,0,1}]}`))
+end
+
+@testset "W2Tex - LaTex conversion" begin
+    @test W2Tex(W`(a+b)^(b+x)`) == "(a+b)^{b+x}"
+    @test W2Tex(W`a`) == "a"
+    @test W2Tex(W`ab`) == "\\text{ab}"
+    @test W2Tex(W`ab*cd`) == "\\text{ab} \\text{cd}"
+
+    ###Testing that MIME form exists for the text/latex option of show.
+    io = IOBuffer();
+    show(IOContext(io, :limit => true, :displaysize => (10, 10)),
+         "text/plain",W"a")
+    @test String(take!(io)) == "W\"a\""
+    show(IOContext(io, :limit => true, :displaysize => (10, 10)),
+         "text/plain",W"a"+W"b")
+    @test String(take!(io)) == "W\"Plus\"(W\"a\", W\"b\")"
+end
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,8 @@ using Test
 
 import MathLink: WExpr, WSymbol
 
+
+
 @testset "integers" begin
     w = W"Factorial"(30)
     @test_throws MathLink.MathLinkError weval(Int, w)
@@ -206,19 +208,28 @@ end
     @test HasRecursiveGraphicsHead(weval(W`{Plot[x,{x,0,1}],Plot[x^2,{x,0,1}]}`))
 end
 
+
+
 @testset "W2Tex - LaTex conversion" begin
     @test W2Tex(W`(a+b)^(b+x)`) == "(a+b)^{b+x}"
     @test W2Tex(W`a`) == "a"
     @test W2Tex(W`ab`) == "\\text{ab}"
     @test W2Tex(W`ab*cd`) == "\\text{ab} \\text{cd}"
 
+   
     ###Testing that MIME form exists for the text/latex option of show.
     io = IOBuffer();
-    show(IOContext(io, :limit => true, :displaysize => (10, 10)),
-         "text/plain",W"a")
+    ioc = IOContext(io, :limit => true, :displaysize => (10, 10)) 
+    show(ioc,"text/plain",W"a")
     @test String(take!(io)) == "W\"a\""
-    show(IOContext(io, :limit => true, :displaysize => (10, 10)),
-         "text/plain",W"a"+W"b")
+    show(ioc,"text/plain",W"a"+W"b")
     @test String(take!(io)) == "W\"Plus\"(W\"a\", W\"b\")"
+
+    set_texOutput(true)
+    show(ioc,"text/latex",W"a"+W"b")
+    @test String(take!(io)) == "\$a+b\$"
+    @test showable("text/latex",W"a"+W"b")
+    set_texOutput(false)
+    @test !showable("text/latex",W"a"+W"b")
 end
 


### PR DESCRIPTION
Next set of features from MathLinks extras: Jupyter notebooks.

There is also some code to make sure that MathLinks does not try to render graphics in tex (since the tex mime type is checked before the graphics one). 