### PR TITLE
Included the W2Mstr function

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,43 @@ julia> P12 * [W"a" W"b" ; W`a+b` 2] == [ W"b" 2-W"b" ; W"a" W"b"]
 true
 ```
 
+
+## W2Mstr - Mathematica conversion
+Sometimes one wants to be able to read the Julia MathLink expressions back into Mathematica. For that purpose, `W2Mstr` is also supplied. This implementation is currently quite defensive with parentheses, which gives a more verbose output than necessary. Here are a few examples
+
+```julia
+julia> W2Mstr(W`x`)
+"x"
+
+julia> W2Mstr(W"Sin"(W"x"))
+"Sin[x]"
+
+julia> W2Mstr(weval(W`a + c + v`))
+"(a + c + v)"
+
+julia> W2Mstr(weval(W`a^(b+c)`))
+"(a^(b + c))"
+
+julia> W2Mstr(weval(W`e+a^(b+c)`))
+"((a^(b + c)) + e)"
+
+julia> W2Mstr(W"a"+W"c"+W"v"+W"Sin"(2 +W"x" + W"Cos"(W"q")))
+"(a + c + v + Sin[(2 + x + Cos[q])])"
+
+julia> W2Mstr(im*2)
+"(2*I)"
+
+julia> W2Mstr(weval(W"Complex"(W"c",W"b")))
+"(c+b*I)"
+
+julia> W2Mstr(W"c"+im*W"b")
+"(((1*I)*b) + c)"
+
+julia> W2Mstr(W`b/(c^(a+c))`)
+"(b*((c^(a + c))^-1))"
+```
+
+
 ## LateX printing in JuPyter Notebooks
 Printing in Juypter notebooks is by defaults done in latex.
 This can be turned off with the command `MathLink.set_texOutput(false)`

--- a/src/display.jl
+++ b/src/display.jl
@@ -93,4 +93,116 @@ function Base.show(io,::MIME"text/latex",x::MathLink.WExpr)
 end
 
 
+export Wprint
+
+####..............
+
+function Wprint(WExpr)
+    weval(W"Print"(WExpr))
+    return
+end
+
+export W2Mstr
+
+###function that prints the W-form back to Mathematica Input-language
+
+W2Mstr(x::Number) = "$x"
+W2Mstr(z::Complex) = W2Mstr(WComplex(z))
+W2Mstr(x::Rational) = "($(x.num)/$(x.den))"
+function W2Mstr(x::Array)
+    Dim = length(size(x))
+    Str="{"
+    for j in 1:size(x)[1]
+        if j>1
+            Str*=","
+        end
+        if Dim == 1
+            Str*=W2Mstr(x[j])
+        elseif Dim == 2
+            Str*=W2Mstr(x[j,:])
+        else
+            ###Arrays with larger dimension: $Dim != 1,2 not implemented yet
+        end
+    end
+    Str*="}"
+    return Str
+end
+
+W2Mstr(x::MathLink.WSymbol) = x.name
+function W2Mstr(x::MathLink.WExpr)
+    #println("W2Mstr::",x.head.name)
+    if x.head.name == "Plus"
+        Str = W2Mstr_PLUS(x.args)
+    elseif x.head.name == "Times"
+        Str = W2Mstr_TIMES(x.args)
+    elseif x.head.name == "Power"
+        Str = W2Mstr_POWER(x.args)
+    elseif x.head.name == "Complex"
+        Str = W2Mstr_COMPLEX(x.args)
+    else
+        Str=x.head.name*"["
+        for j in 1:length(x.args)
+            if j>1
+                Str*=","
+            end
+            Str*=W2Mstr(x.args[j])
+        end
+        Str*="]"
+    end
+    return Str
+end
+            
+function W2Mstr_PLUS(x::Union{Array,Tuple})
+    #println("W2Mstr_PLUS:",x)
+    Str="("
+    for j in 1:length(x)
+        if j>1
+            Str*=" + "
+        end
+        Str*=W2Mstr(x[j])
+    end
+    Str*=")"
+end
+    
+function W2Mstr_TIMES(x::Union{Array,Tuple})
+    #println("W2Mstr_TIMES:",x)
+    Str="("
+    for j in 1:length(x)
+        if j>1
+            Str*="*"
+        end
+        Str*=W2Mstr(x[j])
+    end
+    Str*=")"
+end
+    
+    
+function W2Mstr_POWER(x::Union{Array,Tuple})
+    #println("W2Mstr_POWER:",x)
+    if length(x) != 2
+        error("Power takes two arguments")
+    end
+    Str="("*W2Mstr(x[1])*"^"*W2Mstr(x[2])*")"
+end
+
+
+    
+function W2Mstr_COMPLEX(x::Union{Tuple,Array})
+    #println("W2Mstr_COMPLEX:",x)
+    if length(x) != 2
+        error("Complex takes two arguments")
+    end
+    if x[1] == 0
+        ###Imaginary
+        Str="("*W2Mstr(x[2])*"*I)"
+    elseif x[2] == 0
+        ### Real
+        ###Complex
+        Str=W2Mstr(x[1])
+    else
+        ###Complex
+        Str="("*W2Mstr(x[1])*"+"*W2Mstr(x[2])*"*I)"
+    end
+end
+
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,6 +5,67 @@ import MathLink: WExpr, WSymbol
 
 
 
+@testset "W2Mstr" begin
+    ###Test of a naive MathLink to Mathematica converter function (to resuts can be copied into mathematica directly"
+
+    @testset "Basic Algebra" begin
+        @test W2Mstr(W"a") == "a"
+        @test W2Mstr(W"x") == "x"
+        @test W2Mstr(W"x"+W"y") == "(x + y)"
+        @test W2Mstr(W`Sqrt[a + b]`) == "Sqrt[(a + b)]"
+        @test W2Mstr(W`Pow[x,2]`) == "Pow[x,2]"
+        @test W2Mstr(W`x^2`) == "(x^2)"
+        @test W2Mstr(W`a+b`) == "(a + b)"
+        @test W2Mstr(weval(W`a + c + v`)) == "(a + c + v)"
+        @test W2Mstr(2) == "2"
+        @test W2Mstr(W`x`) == "x"
+        @test W2Mstr(W"Sin"(W"x")) == "Sin[x]"
+        @test W2Mstr(W`Sin[x]`) == "Sin[x]"
+        
+    end    
+    @testset "Nested functions" begin
+        @test W2Mstr(weval(W`a + c*b + v`)) == "(a + (b*c) + v)"
+        @test W2Mstr(weval(W`(a + c)*(b + v)`)) == "((a + c)*(b + v))"
+        @test W2Mstr(weval(W`a^(b+c)`)) == "(a^(b + c))"
+        @test W2Mstr(weval(W`a^2`)) == "(a^2)"
+        @test W2Mstr(weval(W`e+a^(b+c)`)) == "((a^(b + c)) + e)"
+        @test W2Mstr(weval(W`a + c + v + Sin[2 + x + Cos[q]]`)) == "(a + c + v + Sin[(2 + x + Cos[q])])"
+        @test W2Mstr(W"a"+W"c"+W"v"+W"Sin"(2 +W"x" + W"Cos"(W"q"))) == "(a + c + v + Sin[(2 + x + Cos[q])])"
+        @test W2Mstr(W`Sqrt[x+Sin[y]+z^(3/2)]`) == "Sqrt[(x + Sin[y] + (z^(3*(2^-1))))]"
+
+    end
+
+    @testset "Complex values" begin
+        @test W2Mstr(weval(W`2*I`)) == "(2*I)"
+        @test W2Mstr(weval(W`2/I`)) == "(-2*I)"
+        @test W2Mstr(W`2 + 0*I`) == "(2 + (0*I))"
+        @test W2Mstr(W"Complex"(W"c",0)) == "c"
+        @test W2Mstr(weval(W"Complex"(W"c",0))) == "c"
+        @test W2Mstr(weval(W"Complex"(W"c",W"b"))) == "(c+b*I)"
+        @test W2Mstr(im) == "(1*I)"
+        @test W2Mstr(2*im) == "(2*I)"
+    end
+
+    @testset "Factions" begin
+        @test W2Mstr(W`3/4`) == "(3*(4^-1))"
+        @test W2Mstr(3//4) == "(3/4)"
+        @test W2Mstr(W`b/c`) == "(b*(c^-1))"
+        @test W2Mstr(W`b/(c^(a+c))`) == "(b*((c^(a + c))^-1))"
+        @test W2Mstr(W`(b^2)/(c^3)`) == "((b^2)*((c^3)^-1))"
+        @test W2Mstr(weval(W`(b^2)/(c^3)`)) == "((b^2)*(c^-3))"
+    end
+
+    @testset "Lists & Arrays" begin
+        @test W2Mstr([W`x`,W`a`]) == "{x,a}"
+        @test W2Mstr([W`x`]) == "{x}"
+        @test W2Mstr([W`x` W`y`; W`z` W`x`]) == "{{x,y},{z,x}}"
+    end
+    
+end
+
+
+
+
 @testset "integers" begin
     w = W"Factorial"(30)
     @test_throws MathLink.MathLinkError weval(Int, w)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -30,7 +30,11 @@ import MathLink: WExpr, WSymbol
         @test W2Mstr(weval(W`a^2`)) == "(a^2)"
         @test W2Mstr(weval(W`e+a^(b+c)`)) == "((a^(b + c)) + e)"
         @test W2Mstr(weval(W`a + c + v + Sin[2 + x + Cos[q]]`)) == "(a + c + v + Sin[(2 + x + Cos[q])])"
+        set_GreedyEval(true)
         @test W2Mstr(W"a"+W"c"+W"v"+W"Sin"(2 +W"x" + W"Cos"(W"q"))) == "(a + c + v + Sin[(2 + x + Cos[q])])"
+        set_GreedyEval(false)
+        @test W2Mstr(W"a"+W"c"+W"v"+W"Sin"(2 +W"x" + W"Cos"(W"q"))) == "(((a + c) + v) + Sin[((2 + x) + Cos[q])])"
+
         @test W2Mstr(W`Sqrt[x+Sin[y]+z^(3/2)]`) == "Sqrt[(x + Sin[y] + (z^(3*(2^-1))))]"
 
     end


### PR DESCRIPTION
The last of the MathLinkExtras additions.

This implements the W2Mstr function with transforms the MathLink object back into Mathematica input code if one want to paste it directly into Mathematica. 

Here is use M in W2Mstr for Mathematica, and W for MathLink objects.
