### PR TITLE
Cleanup parsing of macros

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,16 +20,16 @@ julia> W"Sin"
 W"Sin"
 
 julia> sin1 = W"Sin"(1.0)
-W"Sin"(1.0)
+W`Sin[1.0]`
 
 julia> sinx = W"Sin"(W"x")
-W"Sin"(W"x")
+W`Sin[x]`
 ```
 
 To parse an expression in the Wolfram Language, you can use the `W` cmd macro (note the backticks):
 ```julia
 julia> W`Sin[1]`
-W"Sin"(1)
+W`Sin[1]`
 ```
 
 `weval` evaluates an expression:
@@ -38,10 +38,10 @@ julia> weval(sin1)
 0.8414709848078965
 
 julia> weval(sinx)
-W"Sin"(W"x")
+W`Sin[x]`
 
 julia> weval(W"Integrate"(sinx, (W"x", 0, 1)))
-W"Plus"(1, W"Times"(-1, W"Cos"(1)))
+W`Plus[1, Times[-1, Cos[1]]]`
 ```
 
 Keyword arguments can be used to pass local variables
@@ -58,24 +58,25 @@ MathLink also overloads the `+`, `-`, `*`, `/`  operations.
 julia> using MathLink
 
 julia> W"a"+W"b"
-W"Plus"(W"a",W"b")
+W`Plus[a, b]`
 
 julia> W"a"+W"a"
-W"Plus"(W"a",W"a")
+W`Plus[a, a]`
 
 julia> W"a"-W"a"
-W"Plus"(W"a",W"Minus"(W"a"))
+W`Plus[a, Minus[a]]`
 ```
 
 One can toggle automatic use of `weval`  on-and-off using `set_GreedyEval(x::Bool)`
 
 ```julia
-julia>set_GreedyEval(true)
+julia> set_GreedyEval(true);
+
 julia> W"a"+W"b"
-W"Plus"(W"a",W"b")
+W`Plus[a, b]`
 
 julia> W"a"+W"a"
-W"Times"(2,W"a")
+W`Times[2, a]`
 
 julia> W"a"-W"a"
 0
@@ -88,23 +89,23 @@ The package also contains extensions to handle fractions.
 
 ```julia
 julia> weval(1//2)
-W"Rational"(1, 2)
+W`Rational[1, 2]`
 
 julia> (4//5)*W"a"
-W"Times"(W"Rational"(4, 5), W"a")
+W`Times[Rational[4, 5], a]`
 
 julia> W"a"/(4//5)
-W"Times"(W"Rational"(5, 4), W"a")
+W`Times[Rational[5, 4], a]`
 ```
 
 and complex numbers
 
 ```julia
 julia> im*W"a"
-W"Times"(W"Complex"(0, 1), W"a")
+W`Times[Complex[0, 1], a]`
 
 julia> im*(im*W"c")
-W"Times"(-1, W"c")
+W`Times[-1, c]`
 ```
 
 

--- a/src/display.jl
+++ b/src/display.jl
@@ -26,7 +26,7 @@ export HasGraphicsHead, HasRecursiveGraphicsHead, W2Tex
 
 
 #### Code to produce LaTex strings
-W2Tex(x::WTypes) = weval(W`ToString@TeXForm[#]&`(x))
+W2Tex(x::WTypes) = weval(W"ToString"(W"TeXForm"(x)))
 
 #### Allow latex string to be shown when supported. Relevant for the jupyter notebook.
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -115,7 +115,14 @@ end
 print_wexpr(io::IO, wsym::WSymbol) = print(io, wsym.name)
 print_wexpr(io::IO, wreal::WReal) = print(io, wreal.value)
 print_wexpr(io::IO, wint::WInteger) = print(io, wint.value)
-print_wexpr(io::IO, x::Float64) = print(io, x)
+function print_wexpr(io::IO, x::Float64) 
+    s = split(string(x),'e')
+    if length(s) == 1
+        print(io, x)
+    else
+        print(io, s[1], "*^", s[2])
+    end
+end
 print_wexpr(io::IO, x::Int) = print(io, x)
 print_wexpr(io::IO, x::String) = show(io, x)
 print_wexpr(io::IO, x) = print(io, "\$(", x, ")")

--- a/src/types.jl
+++ b/src/types.jl
@@ -40,7 +40,7 @@ Base.show(io::IO, s::WSymbol) = print(io, 'W', '"', s.name, '"')
 Base.:(==)(a::WSymbol, b::WSymbol) = a.name == b.name
 
 macro W_str(str)
-    quote WSymbol($(esc(Meta.parse("\"$(escape_string(str))\"")))) end
+    :(WSymbol($str))
 end
 
 """
@@ -81,7 +81,7 @@ julia> weval(W`Function[x,x+1]`(2))
 3
 ```
 """
-struct WExpr <: WTypes
+mutable struct WExpr <: WTypes
     head
     args
 end
@@ -94,20 +94,33 @@ function Base.:(==)(a::WExpr, b::WExpr)
     return true
 end
 
-function Base.show(io::IO, w::WExpr)
-    show(io, w.head)
-    print(io, '(')
-    isfirst = true
-    for arg in w.args
-        if !isfirst
-            print(io, ", ")
-        else
-            isfirst = false
-        end
-        show(io, arg)
-    end
-    print(io, ')')
+function Base.show(io::IO, wexpr::WExpr)
+    print(io, "W`")
+    print_wexpr(io, wexpr)
+    print(io, "`")
 end
+
+function print_wexpr(io::IO, wexpr::WExpr)
+    print_wexpr(io, wexpr.head)
+    print(io, '[')
+    if length(wexpr.args) > 0
+        print_wexpr(io, wexpr.args[1])
+        for arg in wexpr.args[2:end]
+            print(io, ", ")
+            print_wexpr(io, arg)
+        end
+    end
+    print(io, ']')
+end
+print_wexpr(io::IO, wsym::WSymbol) = print(io, wsym.name)
+print_wexpr(io::IO, wreal::WReal) = print(io, wreal.value)
+print_wexpr(io::IO, wint::WInteger) = print(io, wint.value)
+print_wexpr(io::IO, x::Float64) = print(io, x)
+print_wexpr(io::IO, x::Int) = print(io, x)
+print_wexpr(io::IO, x::String) = show(io, x)
+print_wexpr(io::IO, x) = print(io, "\$(", x, ")")
+
+
 
 
 function (w::WSymbol)(args...; kwargs...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -137,9 +137,11 @@ end
 
 @testset "interpolation" begin
     x = exp(1)
-    @test W`Sin[$x]` == W"Sin"(x)
-
+    @test W`Sin[$x]` == W"Sin"(x)    
     @test W`Cos[$(log(2))]` == W"Cos"(log(2))
+
+    @test W`Sin[$(1.2e19)]` == W`Sin[1.2*^19]`
+    @test string(W`Sin[$(1.2e19)]`) == "W`Sin[1.2*^19]`"
 end
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -284,15 +284,12 @@ end
    
     ###Testing that MIME form exists for the text/latex option of show.
     io = IOBuffer();
-    ioc = IOContext(io, :limit => true, :displaysize => (10, 10)) 
-    show(ioc,"text/plain",W"a")
-    @test String(take!(io)) == "W\"a\""
-    show(ioc,"text/plain",W"a"+W"b")
-    @test String(take!(io)) == "W\"Plus\"(W\"a\", W\"b\")"
+    context = IOContext(io, :limit => true, :displaysize => (10, 10)) 
+    @test sprint(show,"text/plain",W"a"; context) == "W\"a\""
+    @test sprint(show,"text/plain",W"a"+W"b"; context) == "W`Plus[a, b]`"
 
     set_texOutput(true)
-    show(ioc,"text/latex",W"a"+W"b")
-    @test String(take!(io)) == "\$a+b\$"
+    @test sprint(show,"text/latex",W"a"+W"b") == "\$a+b\$"
     @test showable("text/latex",W"a"+W"b")
     set_texOutput(false)
     @test !showable("text/latex",W"a"+W"b")


### PR DESCRIPTION
The symbol macro W"" no longer supports $ interpolation The expresion macro W`` supports $ interpolation, but now does it directly rather than converting via text