### PR TITLE
fix undefined variable in windows build

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -73,10 +73,10 @@ function find_lib_ker()
             wpaths = [ENV["JULIA_WOLFRAM_DIR"]]
         else
             wpaths = String[]
-            for dir in ["C:\\Program Files\\Wolfram Research\\Mathematica", "C:\\Program Files\\Wolfram Research\\Wolfram Engine"]
+            for mpath in ["C:\\Program Files\\Wolfram Research\\Mathematica", "C:\\Program Files\\Wolfram Research\\Wolfram Engine"]
                 if isdir(mpath)
                     for ver in readdir(mpath)
-                        push!(wpaths, joinpath(dir, ver))
+                        push!(wpaths, joinpath(mpath, ver))
                     end
                 end
             end


### PR DESCRIPTION
Building the package on Windows failed with:

```julia
ERROR: LoadError: UndefVarError: `mpath` not defined
Stacktrace:
 [1] find_lib_ker()
   @ Main C:\Users\username\.julia\dev\MathLink\deps\build.jl:77
 [2] top-level scope
   @ C:\Users\username\.julia\dev\MathLink\deps\build.jl:112
 [3] include(fname::String)
   @ Base.MainInclude .\client.jl:489
 [4] top-level scope
   @ none:5
in expression starting at C:\Users\username\.julia\dev\MathLink\deps\build.jl:99
```

I fixed the variable names, now it builds and works fine.