### PR TITLE
Add additional possible path for Mathematica on MacOS

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -27,6 +27,15 @@ function find_lib_ker()
             end
         end
 
+        # Wolfram Mathematica
+        for path in readlines(`mdfind "kMDItemCFBundleIdentifier == 'com.wolfram.*'"`)
+            lib = joinpath(path,"Contents/Frameworks/mathlink.framework/mathlink")
+            ker = joinpath(path,"Contents/MacOS/MathKernel")
+            if isfile(lib) && isfile(ker)
+                return lib, ker
+            end
+        end
+
     elseif Sys.isunix()
         archdir = Sys.ARCH == :arm ?    "Linux-ARM" :
                   Sys.ARCH == :x86_64 ? "Linux-x86-64" :


### PR DESCRIPTION
Thanks for the very nice package!

## Issue

Installation on my machine initially failed with the following message during the package build:
```
ERROR: Error building `MathLink`: 
ERROR: LoadError: Could not find Mathematica or Wolfram Engine installation.
Please set the `JULIA_MATHLINK` and `JULIA_MATHKERNEL` variables.
```

For some context, I'm on an M1 Max Macbook Pro and running macOS Sequoia 15.2. I get the following under "About Wolfram" when I look in Mathematica (though "Mathematica" seems to be called "Wolfram for Desktop" now?):
- Version Number: 14.1.0.0
- Platform: Mac OS X ARM (64-bit)

Investigating the paths, it seems that what my machine needed was:
- `ENV["JULIA_MATHLINK"] = joinpath(path, "Contents/Frameworks/mathlink.framework/mathlink")`
- `ENV["JULIA_MATHKERNEL"] = joinpath(path, "Contents/MacOS/MathKernel")`

where `path` was the output of `mdfind "kMDItemCFBundleIdentifier == 'com.wolfram.*'"` (`/Applications/Wolfram.app` on my machine). Guessing it has to do with Wolfram renaming some of these things in recent versions?

## What this PR implements

This PR simply adds this case to the list of cases considered in `deps/build.jl`.

I figure that adding to the end of the list has the least chance of breaking cases that are already working, but perhaps the better fix would be to change
https://github.com/JuliaInterop/MathLink.jl/blob/5f6c5d0c41fa58cd042c7456a9e41bc0d804d01c/deps/build.jl#L11
to instead be
```julia
for path in readlines(`mdfind "kMDItemCFBundleIdentifier == 'com.wolfram.*'"`)
```

Also, I saw that @simonbyrne is implementing what looks to be a better long-term solution in #68. However, that seems to currently be blocked by something on the Wolfram side (if I'm understanding correctly), so perhaps this can be useful to some folks in the meantime?